### PR TITLE
Add hostConfigs option for sibling-plugin config

### DIFF
--- a/lib/dprint/dprint.ts
+++ b/lib/dprint/dprint.ts
@@ -84,10 +84,14 @@ const formatters: Readonly<Record<string, Formatter>> = Object.entries(plugins).
     {} as Record<string, Formatter>,
 )
 
-/** Cache to reduce copies of config values. */
 const lastConfigFile: { [key: string]: string | undefined } = {}
 
-function getFormatter(filePath: string, configName: string, configFile: string, log = true): Formatter | undefined {
+function getFormatter(
+    filePath: string,
+    configName: string,
+    configFile: string,
+    log = true,
+): Formatter | undefined {
     const formatter = formatters[configName]
     if (formatter) {
         const configKey = formatter.getPluginInfo().configKey
@@ -117,7 +121,7 @@ function getFormatterByExt(filePath: string, configFile: string, exclude: string
     for (const configName of configNames) {
         const formatter = getFormatter(filePath, configName, configFile, false)
         if (formatter) {
-            return [configFile, formatter] as const
+            return [configName, formatter] as const
         }
     }
     return [] as const
@@ -125,14 +129,21 @@ function getFormatterByExt(filePath: string, configFile: string, exclude: string
 
 /**
  * Format the given text with the given config.
- * @param config The config object.
+ * @param configFile Path to a dprint configuration file (or empty string for none).
+ * @param overrideConfig Inline config for the originating plugin (applied per-call via FormatRequest.overrideConfig).
+ * @param hostConfigs Per-sibling-plugin config. Merged into FormatRequest.overrideConfig on each
+ *   delegated call when the originating plugin invokes a sibling via the host callback
+ *   (e.g. fenced code blocks inside markdown). Keys are plugin names ("typescript", "json", ...).
+ *   Without this, host-invoked plugins fall back to the on-disk configFile only.
  * @param filePath The path to the file.
  * @param fileText The content of the file.
- * @returns The formatted text or undefined. It's undefined if the formatter doesn't change the text.
+ * @param configName The plugin name of the originating formatter.
+ * @returns The formatted text. Returns the input fileText if no formatter applies.
  */
 export function format(
     configFile: string,
     overrideConfig: Record<string, unknown>,
+    hostConfigs: Record<string, Record<string, unknown>>,
     filePath: string,
     fileText: string,
     configName: string,
@@ -146,7 +157,7 @@ export function format(
         }
         return formatter.formatText(
             request,
-            hostRequest => formatWithHost(hostRequest, configFile, configName),
+            hostRequest => formatWithHost(hostRequest, configFile, hostConfigs, configName),
         )
     }
     return fileText
@@ -155,13 +166,20 @@ export function format(
 export function formatWithHost(
     request: FormatRequest,
     configFile: string,
+    hostConfigs: Record<string, Record<string, unknown>>,
     fromConfigName: string,
 ): string {
     const [configName, formatter] = getFormatterByExt(request.filePath, configFile, fromConfigName)
     if (configName && formatter) {
+        const hostConfig = hostConfigs[configName]
+        if (hostConfig && typeof hostConfig === "object") {
+            const overrideConfig: Record<string, unknown> = { ...request.overrideConfig }
+            extractConfig(hostConfig, overrideConfig)
+            request = { ...request, overrideConfig }
+        }
         return formatter.formatText(
             request,
-            hostRequest => formatWithHost(hostRequest, configFile, configName),
+            hostRequest => formatWithHost(hostRequest, configFile, hostConfigs, configName),
         )
     }
     return request.fileText

--- a/lib/rules/dprint.ts
+++ b/lib/rules/dprint.ts
@@ -191,66 +191,98 @@ function createMessage(d: Diff): Message {
         createRepaceMessage(d)
 }
 
-type Options = { readonly configFile?: string; readonly config?: Record<string, unknown> }
-const defaultOptions: Options = { configFile: "dprint.json", config: {} }
+type Options = {
+    readonly configFile?: string
+    readonly config?: Record<string, unknown>
+    readonly hostConfigs?: Record<string, Record<string, unknown>>
+}
+const defaultOptions: Options = { configFile: "dprint.json", config: {}, hostConfigs: {} }
 
 export const dprintRules: { [name: string]: Rule.RuleModule } = configSchemas.map((
     config,
-): { [name: string]: Rule.RuleModule } => ({
-    [config.name]: {
-        meta: {
-            docs: {
-                description: `Format ${config.name} with dprint`,
-                url: `https://github.com/ben12/eslint-plugin-dprint/blob/master/docs/rules/dprint-${config.name}.md`,
-                recommended: true,
-            },
-            fixable: "code",
-            messages,
-            schema: {
-                definitions: config.configSchema.definitions,
-                type: "array",
-                items: [{
-                    type: "object",
-                    properties: {
-                        configFile: {
-                            type: "string",
-                            default: "dprint.json",
-                            description: "dprint configuration file (default 'dprint.json')",
+): { [name: string]: Rule.RuleModule } => {
+    // Allow per-sibling-plugin config to flow into setConfig for host-invoked formatters
+    // (e.g. fenced code blocks inside markdown). Keys are sibling plugin names; the current
+    // plugin is excluded because its own config already goes through `config`/overrideConfig.
+    // Inner values are not strictly validated by schema — dprint's WASM setConfig handles that.
+    const hostConfigsProperties = configSchemas.reduce((acc, sibling) => {
+        if (sibling.name !== config.name) {
+            acc[sibling.name] = { type: "object", additionalProperties: true }
+        }
+        return acc
+    }, {} as Record<string, JSONSchema4>)
+
+    return {
+        [config.name]: {
+            meta: {
+                docs: {
+                    description: `Format ${config.name} with dprint`,
+                    url: `https://github.com/ben12/eslint-plugin-dprint/blob/master/docs/rules/dprint-${config.name}.md`,
+                    recommended: true,
+                },
+                fixable: "code",
+                messages,
+                schema: {
+                    definitions: config.configSchema.definitions,
+                    type: "array",
+                    items: [{
+                        type: "object",
+                        properties: {
+                            configFile: {
+                                type: "string",
+                                default: "dprint.json",
+                                description: "dprint configuration file (default 'dprint.json')",
+                            },
+                            config: {
+                                type: "object",
+                                properties: config.configSchema.properties,
+                                additionalProperties: false,
+                            },
+                            hostConfigs: {
+                                type: "object",
+                                properties: hostConfigsProperties,
+                                additionalProperties: false,
+                                description: "Config applied to sibling plugins when this plugin delegates to them " +
+                                    "(e.g. fenced code blocks). Keys are sibling plugin names.",
+                            },
                         },
-                        config: {
-                            type: "object",
-                            properties: config.configSchema.properties,
-                            additionalProperties: false,
-                        },
-                    },
-                    additionalProperties: false,
-                }],
-                additionalItems: false,
+                        additionalProperties: false,
+                    }],
+                    additionalItems: false,
+                },
+                type: "layout",
             },
-            type: "layout",
+            create: (context) => ({
+                Program() {
+                    const sourceCode = context.sourceCode ?? context.getSourceCode()
+                    const filePath = context.filename ?? context.getFilename()
+                    const fileText = sourceCode.getText()
+                    const options = (context.options[0] as Options) ?? defaultOptions
+                    const configFile = options.configFile ?? "dprint.json"
+                    const configOpt = options.config || {}
+                    const hostConfigs = options.hostConfigs || {}
+
+                    // Needs an absolute path
+                    if (!filePath || !path.isAbsolute(filePath)) {
+                        return
+                    }
+
+                    // Does format
+                    const formattedText = format(
+                        configFile,
+                        configOpt,
+                        hostConfigs,
+                        filePath,
+                        fileText,
+                        config.name,
+                    )
+
+                    generateLintReports(fileText, formattedText, sourceCode, context)
+                },
+            }),
         },
-        create: (context) => ({
-            Program() {
-                const sourceCode = context.sourceCode ?? context.getSourceCode()
-                const filePath = context.filename ?? context.getFilename()
-                const fileText = sourceCode.getText()
-                const options = (context.options[0] as Options) ?? defaultOptions
-                const configFile = options.configFile ?? "dprint.json"
-                const configOpt = options.config || {}
-
-                // Needs an absolute path
-                if (!filePath || !path.isAbsolute(filePath)) {
-                    return
-                }
-
-                // Does format
-                const formattedText = format(configFile, configOpt, filePath, fileText, config.name)
-
-                generateLintReports(fileText, formattedText, sourceCode, context)
-            },
-        }),
-    },
-})).reduce((r1, r2) => ({ ...r1, ...r2 }), {})
+    }
+}).reduce((r1, r2) => ({ ...r1, ...r2 }), {})
 
 function generateLintReports(
     fileText: string,

--- a/test/rules/dprint-markdown.ts
+++ b/test/rules/dprint-markdown.ts
@@ -44,6 +44,16 @@ tester.run("dprint/markdown", dprintRules.markdown, {
 `,
             options: [{ configFile: "test/dprint.json", config: {} }],
         },
+        // hostConfigs applies sibling-plugin config when markdown delegates to host (TS code block).
+        // No on-disk configFile — proves hostConfigs alone is enough.
+        {
+            filename: path.join(__dirname, "test.md"),
+            code: "```ts\nconst x = 'hi';\n```\n",
+            options: [{
+                configFile: "",
+                hostConfigs: { typescript: { quoteStyle: "preferSingle" } },
+            }],
+        },
     ],
     invalid: [
         {
@@ -142,6 +152,31 @@ tester.run("dprint/markdown", dprintRules.markdown, {
                 data: {},
                 line: 6,
                 column: 4,
+            }],
+        },
+        // hostConfigs reformats embedded TS quotes from double to single, with no on-disk configFile.
+        {
+            filename: path.join(__dirname, "test.md"),
+            code: '```ts\nconst x = "hi";\n```\n',
+            output: "```ts\nconst x = 'hi';\n```\n",
+            options: [{
+                configFile: "",
+                hostConfigs: { typescript: { quoteStyle: "preferSingle" } },
+            }],
+            errors: [{
+                messageId: "replaceCode",
+                data: { oldText: '"\\""', newText: '"\'"' },
+                line: 2,
+                column: 11,
+                endLine: 2,
+                endColumn: 12,
+            }, {
+                messageId: "replaceCode",
+                data: { oldText: '"\\""', newText: '"\'"' },
+                line: 2,
+                column: 14,
+                endLine: 2,
+                endColumn: 15,
             }],
         },
     ],


### PR DESCRIPTION
The markdown plugin delegates fenced code blocks to sibling formatters via the host callback, but those formatters are only configured from on-disk dprint.json, the rule's inline `config` only reaches the originating formatter via overrideConfig. So in an ESLint-only setup (no dprint.json), TS/JSON inside .md files always gets reformatted to dprint defaults, ignoring per-language settings configured elsewhere in the flat config.

`hostConfigs` is a map of sibling-plugin name -> config, merged into pluginConfig when that plugin is reached via the host callback:

```js
{ files: ["**/*.md"], rules: {
    "dprint/markdown": ["error", {
        config: { lineWidth: 120 },
        hostConfigs: { typescript: { quoteStyle: "preferSingle" } },
    }],
}}
```

Cache key in `lastConfigFile` now includes the host override so re-config happens when it changes. Backward compatible, omitting `hostConfigs` reproduces prior behavior.

Also fixes a pre-existing bug in `getFormatterByExt`: it returned `[configFile, formatter]` but the caller in `formatWithHost` destructures as `[configName, formatter]` and gates on truthiness. With `configFile=\"\"`, that gate failed and host formatting silently no-op'd. Existing tests masked this by always setting a non-empty `configFile`.